### PR TITLE
Refine path handling and update tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
     - id: isort
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 24.4.2
     hooks:
     - id: black

--- a/io_xplane2blender/xplane_helpers.py
+++ b/io_xplane2blender/xplane_helpers.py
@@ -1,10 +1,9 @@
 import datetime
 import itertools
-import os
 import re
 from datetime import timezone
-from typing import Iterable, List, Optional, Tuple, Union
 from pathlib import Path
+from typing import Iterable, List, Optional, Tuple, Union
 
 import bpy
 import mathutils
@@ -56,12 +55,25 @@ def floatToStr(n: float) -> str:
 
 
 def resolveBlenderPath(path: str) -> str:
-    blenddir = os.path.dirname(bpy.context.blend_data.filepath)
+    """Resolve Blender-style paths starting with ``//`` to absolute paths.
 
-    if path[0:2] == "//":
-        return os.path.join(blenddir, path[2:])
-    else:
+    Parameters
+    ----------
+    path: str
+        Path that may be relative to the current ``.blend`` file.
+
+    Returns
+    -------
+    str
+        Absolute path corresponding to ``path``.
+    """
+    if not path:
         return path
+
+    blenddir = Path(bpy.context.blend_data.filepath).parent
+    if path.startswith("//"):
+        return str(blenddir / path[2:])
+    return path
 
 
 def effective_normal_metalness(xp_file: "xplane_file.XPlaneFile") -> bool:
@@ -83,7 +95,8 @@ def is_path_decal_lib(file_path: str) -> bool:
 
 
 def get_plugin_resources_folder() -> str:
-    return os.path.join(os.path.dirname(__file__), "resources")
+    """Return the path to this add-on's resources folder."""
+    return str(Path(__file__).parent / "resources")
 
 
 def get_potential_objects_in_exportable_root(
@@ -107,7 +120,7 @@ def get_potential_objects_in_exportable_root(
 
 
 def get_rotation_from_rotatable(
-    obj_or_bone: Union[bpy.types.Object, bpy.types.PoseBone]
+    obj_or_bone: Union[bpy.types.Object, bpy.types.PoseBone],
 ) -> Union[mathutils.Euler, mathutils.Quaternion, Tuple[float, float, float, float]]:
     """Returns a copy of the rotation, in whatever mode was given"""
     rotation_mode = obj_or_bone.rotation_mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-black==19.10b0
-isort==4.3.21
-pre-commit==2.7.1
+black==24.4.2
+isort==5.13.2
+pre-commit==3.7.0

--- a/run.py
+++ b/run.py
@@ -6,9 +6,10 @@
 # python3 run.py --blender /Applications/Blender.app/Contents/MacOS/Blender
 
 import argparse
-import os
 import subprocess
 import sys
+from pathlib import Path
+
 
 def _make_argparse():
     parser = argparse.ArgumentParser(description="Runs the XPlane2Blender test suite")
@@ -35,6 +36,18 @@ def _make_argparse():
 
 
 def main(argv=None) -> int:
+    """Launch Blender with the XPlane2Blender add-on loaded.
+
+    Parameters
+    ----------
+    argv: argparse.Namespace | None
+        Parsed arguments. If ``None``, arguments are read from ``sys.argv``.
+
+    Returns
+    -------
+    int
+        The exit code returned by Blender.
+    """
 
     if argv is None:
         argv = _make_argparse().parse_args(sys.argv[1:])
@@ -43,7 +56,7 @@ def main(argv=None) -> int:
         argv.blender,
         "--addons",
         "io_xplane2blender",
-                "--factory-startup",
+        "--factory-startup",
     ]
 
     if argv.no_factory_startup:
@@ -62,15 +75,14 @@ def main(argv=None) -> int:
     print(" ".join(blender_args))
 
     # Environment variables - in order for --addons to work, we need to have OUR folder
-    # exist, and we need to have "addons/modules" simlink BACK to us to create the illusion
+    # exist, and we need to have "addons/modules" symlink back to us to create the illusion
     # of the directory structure Blender expects.
-    enviro={"BLENDER_USER_SCRIPTS": os.path.dirname(os.path.realpath(__file__))}
+    enviro = {"BLENDER_USER_SCRIPTS": str(Path(__file__).resolve().parent)}
 
     # Run Blender, normalize output line endings because Windows is dumb
-    out = subprocess.run(
-        blender_args, universal_newlines=True, env=enviro
-    )  # type: str
+    out = subprocess.run(blender_args, universal_newlines=True, env=enviro)
+    return out.returncode
 
 
-main()
-
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- use pathlib in exporter and helper utilities
- document path helpers and streamline run.py entrypoint
- upgrade formatting toolchain versions

## Testing
- `pre-commit run --files run.py io_xplane2blender/xplane_export.py io_xplane2blender/xplane_helpers.py requirements.txt .pre-commit-config.yaml`
- `python tests.py -q` *(fails: No such file or directory: 'blender')*


------
https://chatgpt.com/codex/tasks/task_e_68ae8acb2ae083329c162b0d5dda2208